### PR TITLE
UIAccessibility/VoiceOver support

### DIFF
--- a/Example/MKRingProgressViewExample/MKRingProgressGroupView.swift
+++ b/Example/MKRingProgressViewExample/MKRingProgressGroupView.swift
@@ -108,4 +108,24 @@ class MKRingProgressGroupView: UIView {
 
     }
 
+    // Accessibility for grouped rings
+    
+    open override var isAccessibilityElement: Bool {
+        get { return true }
+        set { }
+    }
+    
+    open override var accessibilityFrame: CGRect {
+        get { return self.convert(bounds, to: UIScreen.main.coordinateSpace) }
+        set { }
+    }
+    
+    open override var accessibilityLabel: String? {
+        get { return """
+            \(ring1.accessibilityIdentifier ?? "Ring 1"): \(ring1.progress * 100) %,
+            \(ring2.accessibilityIdentifier ?? "Ring 2"): \(ring2.progress * 100) %,
+            \(ring3.accessibilityIdentifier ?? "Ring 3"): \(ring3.progress * 100) %
+            """ }
+        set { }
+    }
 }

--- a/Example/MKRingProgressViewExample/MKRingProgressGroupView.swift
+++ b/Example/MKRingProgressViewExample/MKRingProgressGroupView.swift
@@ -107,25 +107,4 @@ class MKRingProgressGroupView: UIView {
         ring3.frame = bounds.insetBy(dx: 2 * ringWidth + 2 * ringSpacing, dy: 2 * ringWidth + 2 * ringSpacing)
 
     }
-
-    // Accessibility for grouped rings
-    
-    open override var isAccessibilityElement: Bool {
-        get { return true }
-        set { }
-    }
-    
-    open override var accessibilityFrame: CGRect {
-        get { return self.convert(bounds, to: UIScreen.main.coordinateSpace) }
-        set { }
-    }
-    
-    open override var accessibilityLabel: String? {
-        get { return """
-            \(ring1.accessibilityIdentifier ?? "Ring 1"): \(ring1.progress * 100) %,
-            \(ring2.accessibilityIdentifier ?? "Ring 2"): \(ring2.progress * 100) %,
-            \(ring3.accessibilityIdentifier ?? "Ring 3"): \(ring3.progress * 100) %
-            """ }
-        set { }
-    }
 }

--- a/Example/MKRingProgressViewExample/ViewController.swift
+++ b/Example/MKRingProgressViewExample/ViewController.swift
@@ -24,12 +24,12 @@ class ViewController: UIViewController {
         
         let containerView = UIView(frame: navigationController!.navigationBar.bounds)
         navigationController!.navigationBar.addSubview(containerView)
-        
+
         // These are optional and only serve to improve accessibility
-        progressGroup.ring1.identifier = "Move"
-        progressGroup.ring2.identifier = "Exercise"
-        progressGroup.ring3.identifier = "Stand"
-        
+        progressGroup.ring1.accessibilityLabel = "Move"
+        progressGroup.ring2.accessibilityLabel = "Exercise"
+        progressGroup.ring3.accessibilityLabel = "Stand"
+
         let n = 7
         for i in 0..<n {
             let w = (containerView.bounds.width - 16) / CGFloat(n)

--- a/Example/MKRingProgressViewExample/ViewController.swift
+++ b/Example/MKRingProgressViewExample/ViewController.swift
@@ -25,6 +25,11 @@ class ViewController: UIViewController {
         let containerView = UIView(frame: navigationController!.navigationBar.bounds)
         navigationController!.navigationBar.addSubview(containerView)
         
+        // These are optional and only serve to improve accessibility
+        progressGroup.ring1.identifier = "Move"
+        progressGroup.ring2.identifier = "Exercise"
+        progressGroup.ring3.identifier = "Stand"
+        
         let n = 7
         for i in 0..<n {
             let w = (containerView.bounds.width - 16) / CGFloat(n)

--- a/MKRingProgressView/MKRingProgressView.swift
+++ b/MKRingProgressView/MKRingProgressView.swift
@@ -136,6 +136,13 @@ open class MKRingProgressView: UIView {
     
     // Accessibility for individual rings
     
+    /// A unique string descriptor for the ring that is also used for accessibility.
+    @objc open var identifier: String? {
+        didSet {
+            accessibilityIdentifier = identifier
+        }
+    }
+    
     open override var isAccessibilityElement: Bool {
         get { return true }
         set { }
@@ -147,7 +154,7 @@ open class MKRingProgressView: UIView {
     }
     
     open override var accessibilityLabel: String? {
-        get { return "\(accessibilityIdentifier ?? "Ring"): \(self.progress * 100) %" }
+        get { return "\(identifier ?? accessibilityIdentifier ?? "Ring"): \(self.progress * 100) %" }
         set { }
     }
 }

--- a/MKRingProgressView/MKRingProgressView.swift
+++ b/MKRingProgressView/MKRingProgressView.swift
@@ -129,11 +129,27 @@ open class MKRingProgressView: UIView {
     open override class var layerClass: AnyClass {
         return MKRingProgressLayer.self
     }
-        
+    
     private var ringProgressLayer: MKRingProgressLayer {
         return layer as! MKRingProgressLayer
     }
     
+    // Accessibility for individual rings
+    
+    open override var isAccessibilityElement: Bool {
+        get { return true }
+        set { }
+    }
+    
+    open override var accessibilityFrame: CGRect {
+        get { return self.convert(bounds, to: UIScreen.main.coordinateSpace) }
+        set { }
+    }
+    
+    open override var accessibilityLabel: String? {
+        get { return "\(accessibilityIdentifier ?? "Ring"): \(self.progress * 100) %" }
+        set { }
+    }
 }
 
 @objc(MKRingProgressViewStyle)

--- a/MKRingProgressView/MKRingProgressView.swift
+++ b/MKRingProgressView/MKRingProgressView.swift
@@ -164,7 +164,7 @@ open class MKRingProgressView: UIView {
             if let override = overriddenAccessibilityValue {
                 return override
             }
-            return "\(progress * 100) %"
+            return String(format: "%.f%%", progress * 100)
         }
         set {
             overriddenAccessibilityValue = newValue

--- a/MKRingProgressView/MKRingProgressView.swift
+++ b/MKRingProgressView/MKRingProgressView.swift
@@ -133,29 +133,42 @@ open class MKRingProgressView: UIView {
     private var ringProgressLayer: MKRingProgressLayer {
         return layer as! MKRingProgressLayer
     }
-    
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setup()
+    }
+
+    init() {
+        super.init(frame: .zero)
+        setup()
+    }
+
+    private func setup() {
+        isAccessibilityElement = true
+        accessibilityTraits = UIAccessibilityTraitUpdatesFrequently
+        accessibilityLabel = "Ring progress"
+    }
+
     // Accessibility for individual rings
-    
-    /// A unique string descriptor for the ring that is also used for accessibility.
-    @objc open var identifier: String? {
-        didSet {
-            accessibilityIdentifier = identifier
+
+    private var overriddenAccessibilityValue: String?
+
+    open override var accessibilityValue: String? {
+        get {
+            if let override = overriddenAccessibilityValue {
+                return override
+            }
+            return "\(progress * 100) %"
         }
-    }
-    
-    open override var isAccessibilityElement: Bool {
-        get { return true }
-        set { }
-    }
-    
-    open override var accessibilityFrame: CGRect {
-        get { return self.convert(bounds, to: UIScreen.main.coordinateSpace) }
-        set { }
-    }
-    
-    open override var accessibilityLabel: String? {
-        get { return "\(identifier ?? accessibilityIdentifier ?? "Ring"): \(self.progress * 100) %" }
-        set { }
+        set {
+            overriddenAccessibilityValue = newValue
+        }
     }
 }
 


### PR DESCRIPTION
Thanks for the library!

I noticed the rings weren't accessible to a screenreader user, so I thought it might be worth adding. The only additional property I've added is the ```identifier: String?``` in MKRingProgressView and it is optional. 

The reason these are computed properties is mostly to account for updated frames on rotation. Also, note that grouped accessibility overrides individual accessibility, but this is intentional and supports users of the library that use them grouped or one at a time.

Happy to make changes as needed.