### PR TITLE
Error compiling with Xcode 10 GM / Swift 4.2 - UIAccessibilityTraitUpdatesFrequently

### DIFF
--- a/MKRingProgressView/MKRingProgressView.swift
+++ b/MKRingProgressView/MKRingProgressView.swift
@@ -158,7 +158,11 @@ open class RingProgressView: UIView {
         layer.drawsAsynchronously = true
         layer.contentsScale = UIScreen.main.scale
         isAccessibilityElement = true
+        #if swift(>=4.2)
+        accessibilityTraits = UIAccessibilityTraits.updatesFrequently
+        #else
         accessibilityTraits = UIAccessibilityTraitUpdatesFrequently
+        #endif
         accessibilityLabel = "Ring progress"
     }
 


### PR DESCRIPTION
This PR checks the Swift version in use and conditionally compiles `UIAccessibilityTraits.updatesFrequently` correcrtly for Swift >=4.2 or fallback to the current implementation for older versions.

It also bumps the podspec version for a new.