### PR TITLE
Added possibility to hide progress ring shadow, if progress is 0.0.

### DIFF
--- a/MKRingProgressView/MKRingProgressLayer.swift
+++ b/MKRingProgressView/MKRingProgressLayer.swift
@@ -28,7 +28,7 @@ import UIKit
 open class RingProgressLayer: CALayer {
 
     ///Do not show progress ring if progress is 0.0
-    @objc open var hideIfNoProgress = false {
+    @objc open var hideShadowIfNoProgress = false {
         didSet {
             setNeedsDisplay()
         }
@@ -190,7 +190,7 @@ open class RingProgressLayer: CALayer {
 
         // Draw shadow
 
-        if endShadowOpacity > 0.0 && (!hideIfNoProgress || p > 0.0) {
+        if endShadowOpacity > 0.0 && (!hideShadowIfNoProgress || p > 0.0) {
             ctx.saveGState()
 
             ctx.addPath(CGPath(__byStroking: circlePath.cgPath,

--- a/MKRingProgressView/MKRingProgressLayer.swift
+++ b/MKRingProgressView/MKRingProgressLayer.swift
@@ -27,6 +27,13 @@ import UIKit
 @objc(MKRingProgressLayer)
 open class RingProgressLayer: CALayer {
 
+    ///Do not show progress ring if progress is 0.0
+    @objc open var hideIfNoProgress = false {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    
     /// The progress ring start color.
     @objc open var startColor = UIColor.red.cgColor {
         didSet {
@@ -183,7 +190,7 @@ open class RingProgressLayer: CALayer {
 
         // Draw shadow
 
-        if endShadowOpacity > 0.0 {
+        if endShadowOpacity > 0.0 && (!hideIfNoProgress || p > 0.0) {
             ctx.saveGState()
 
             ctx.addPath(CGPath(__byStroking: circlePath.cgPath,

--- a/MKRingProgressView/MKRingProgressView.swift
+++ b/MKRingProgressView/MKRingProgressView.swift
@@ -34,13 +34,13 @@ public enum RingProgressViewStyle: Int {
 @objc(MKRingProgressView)
 open class RingProgressView: UIView {
 
-    /// Hide the progress ring if progress is 0.0. This will still display the backdrop circle. Defaults to `false`
-    @IBInspectable open var hideIfNoProgress: Bool {
+    /// Hide the progress ring shadow if progress is 0.0. Defaults to `false`
+    @IBInspectable open var hideShadowIfNoProgress: Bool {
         get {
-            return ringProgressLayer.hideIfNoProgress
+            return ringProgressLayer.hideShadowIfNoProgress
         }
         set {
-            ringProgressLayer.hideIfNoProgress = newValue
+            ringProgressLayer.hideShadowIfNoProgress = newValue
         }
     }
     

--- a/MKRingProgressView/MKRingProgressView.swift
+++ b/MKRingProgressView/MKRingProgressView.swift
@@ -34,6 +34,16 @@ public enum RingProgressViewStyle: Int {
 @objc(MKRingProgressView)
 open class RingProgressView: UIView {
 
+    /// Hide the progress ring if progress is 0.0. This will still display the backdrop circle. Defaults to `false`
+    @IBInspectable open var hideIfNoProgress: Bool {
+        get {
+            return ringProgressLayer.hideIfNoProgress
+        }
+        set {
+            ringProgressLayer.hideIfNoProgress = newValue
+        }
+    }
+    
     /// The start color of the progress ring.
     @IBInspectable open var startColor: UIColor {
         get {


### PR DESCRIPTION
I would like to have the possibility not to show a single "dot" if progess is 0.0, and simply only show the backdrop shadow ring.
I've provided a possible solution for this, though I'm not sure that the naming is optimal.

I would like to hear your thoughts on this.