### PR TITLE
Swift Packager Manager Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "MKRingProgressView",
+    platforms: [.iOS(.v8), .tvOS(.v9)],
+    products: [
+        .library(name: "MKRingProgressView", targets: ["MKRingProgressView"]),
+    ],
+    targets: [
+        .target(name: "MKRingProgressView", path: "MKRingProgressView")
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "MKRingProgressView",
     platforms: [.iOS(.v8), .tvOS(.v9)],
     products: [
-        .library(name: "MKRingProgressView", targets: ["MKRingProgressView"]),
+        .library(name: "MKRingProgressView", targets: ["MKRingProgressView"])
     ],
     targets: [
         .target(name: "MKRingProgressView", path: "MKRingProgressView")


### PR DESCRIPTION
Adds `Package.swift` which enable usage with SPM.
**Note**, that the most correct usage with SPM will be possible only when there is new tag with full semantic version(e.g. "1.2.0", not "1.2") that includes Package.swift. Until then, dependency can be added by branch or commit hash which is not allowed in published packages.